### PR TITLE
Disable accounts page until backend support is implemented

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,7 +83,7 @@ function App() {
             <main className="app-main">
               <Routes>
                 <Route path="/" element={<HomePage />} />
-                <Route path="/account" element={<Account />} />
+                {/* <Route path="/account" element={<Account />} /> */}
 
                 <Route path="/todos" element={<Todo />} />
                 <Route path="/login" element={<Login />} />

--- a/src/components/HeroSectionComponent.jsx
+++ b/src/components/HeroSectionComponent.jsx
@@ -16,9 +16,9 @@ const HeroSectionComponent = () => {
           <h1>Organize Your Day, Your Way</h1>
           <p>Plan smarter. Stay focused. Crush your goals.</p>
           <div className="hero-buttons">
-            <a href="/account" className="btn hero-btn">
+            {/* <a href="/account" className="btn hero-btn">
               View Account
-            </a>
+            </a> */}
             <a href="/todos" className="btn hero-btn secondary">
               Start keeping track of your tasks
             </a>

--- a/src/components/TopNavBarComponent.jsx
+++ b/src/components/TopNavBarComponent.jsx
@@ -113,7 +113,7 @@ const SideNavBarComponent = ({
                   icon={<FiCheckSquare />}
                   label="Manage Todos"
                 />
-                <NavItem to="/account" icon={<FiUser />} label="Account" />
+                {/* <NavItem to="/account" icon={<FiUser />} label="Account" /> */}
               </>
             )}
           </ul>


### PR DESCRIPTION
This pull request temporarily removes all user-facing navigation and UI elements related to the `/account` page. The `/account` route, navigation link, and hero section button have been commented out, making the account page inaccessible from the app's interface.

UI and Navigation Updates:

* [`src/App.jsx`](diffhunk://#diff-d274a54187c91ba0f532df2a9e194e27ab50e988f5e4c33f5a7893918320c661L86-R86): Commented out the `/account` route to prevent routing to the account page.
* [`src/components/HeroSectionComponent.jsx`](diffhunk://#diff-4befcd626eae559fe4f6b5d170d816493d7e36ca3b4329c4f2fd0b2931299330L19-R21): Commented out the "View Account" button in the hero section.
* [`src/components/TopNavBarComponent.jsx`](diffhunk://#diff-e16e94419f12cfbac7f97461427a3c43a2382da45e8547b917944b9aa8823144L116-R116): Commented out the "Account" navigation item in the side navigation bar.